### PR TITLE
Bump plugin version to 1.0.2

### DIFF
--- a/gn-password-login-api.php
+++ b/gn-password-login-api.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Password Login API
  * Description: Secure REST login via username/email + password with rate limiting, HTTPS checks, and one-time token login URL for cross-origin/mobile apps.
- * Version: 1.0.1
+ * Version: 1.0.2
  * Author: George Nicolaou
  * License: GPL-2.0+
  */

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: rest api, login, authentication, mobile, spa
 Requires at least: 5.8
 Tested up to: 6.4
 Requires PHP: 7.4
-Stable tag: 1.0.1
+Stable tag: 1.0.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -45,10 +45,16 @@ Only when using the `cookie` mode from the same origin as the WordPress site. Cr
 
 == Changelog ==
 
+= 1.0.2 =
+* Version bump for maintenance release.
+
 = 1.0.1 =
 * Initial public release of the hardened password login REST API.
 
 == Upgrade Notice ==
+
+= 1.0.2 =
+Version bump for maintenance release.
 
 = 1.0.1 =
 This release introduces the secure REST login endpoint with rate limiting, token hand-offs, and admin-configurable CORS support.


### PR DESCRIPTION
## Summary
- bump the plugin header version and stable tag to 1.0.2 for the new release
- add 1.0.2 entries to the changelog and upgrade notice documenting the maintenance release

## Testing
- php -l gn-password-login-api.php

------
https://chatgpt.com/codex/tasks/task_e_68dad1a2e69c8327a86188e04b64c2d5