### PR TITLE
Add registration and password reset REST endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # GN Password Login API
 
-GN Password Login API is a WordPress plugin that exposes a hardened REST endpoint for username/email + password logins. It is designed for SPAs, mobile apps, and other cross-origin clients that need to authenticate against a WordPress site without sending users through the default login form.
+GN Password Login API is a WordPress plugin that exposes hardened REST endpoints for authenticating, registering, and resetting WordPress user passwords. It is designed for SPAs, mobile apps, and other cross-origin clients that need to manage accounts without sending users through the default WordPress forms.
 
 ## Features
 
 - **REST login endpoint:** `POST /wp-json/gn/v1/login` accepts `username`, `password`, optional `remember`, `mode`, and `redirect_to` parameters.
+- **Account registration endpoint:** `POST /wp-json/gn/v1/register` creates a new user with validated username, email, and password (optional profile fields supported).
+- **Password reset initiation:** `POST /wp-json/gn/v1/forgot-password` triggers the core WordPress reset email without revealing whether the account exists.
 - **HTTPS enforcement:** rejects requests made over insecure HTTP (unless `ALLOW_DEV_HTTP` is enabled for local development).
 - **Rate limiting:** caps login attempts to 5 per 15-minute window per IP address and username.
 - **Flexible identifiers:** allows users to authenticate using either their username or email address.
@@ -54,6 +56,53 @@ To complete the flow, open `token_login_url` in a browser/webview. The plugin va
 
 When `mode` is set to `cookie`, the endpoint immediately sets the auth cookies and returns a simplified success payload for same-origin usage.
 
+### Registration
+
+```http
+POST /wp-json/gn/v1/register HTTP/1.1
+Host: example.com
+Content-Type: application/json
+
+{
+  "username": "newuser",
+  "email": "newuser@example.com",
+  "password": "aSecurePassword123",
+  "first_name": "New",
+  "last_name": "User"
+}
+```
+
+Successful response:
+
+```json
+{
+  "success": true,
+  "message": "Account created successfully.",
+  "user_id": 456
+}
+```
+
+### Password reset
+
+```http
+POST /wp-json/gn/v1/forgot-password HTTP/1.1
+Host: example.com
+Content-Type: application/json
+
+{
+  "login": "user@example.com"
+}
+```
+
+Response (the message is identical even if the account does not exist to prevent enumeration):
+
+```json
+{
+  "success": true,
+  "message": "If the account exists, a password reset email has been sent."
+}
+```
+
 ## Configuration
 
 1. Install and activate the plugin like any other WordPress plugin.
@@ -63,6 +112,8 @@ When `mode` is set to `cookie`, the endpoint immediately sets the auth cookies a
 ## Security considerations
 
 - Requests are rate limited per IP and per username. Further protections (e.g. reCAPTCHA) can be layered on if desired.
+- Registration validates usernames, enforces unique emails, and requires passwords of at least eight characters.
+- Password reset responses remain generic when the account is unknown to avoid user enumeration.
 - The plugin intentionally returns a generic error message for failed logins to avoid user enumeration.
 - One-time tokens expire after 60 seconds and are restricted to the requesting IP/UA pair for additional safety.
 - Redirect targets are sanitized to prevent external redirects.

--- a/readme.txt
+++ b/readme.txt
@@ -5,22 +5,24 @@ Tags: rest api, login, authentication, mobile, spa
 Requires at least: 5.8
 Tested up to: 6.4
 Requires PHP: 7.4
-Stable tag: 1.0.2
+Stable tag: 1.1.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
-Provides a hardened REST endpoint for WordPress logins with rate limiting, HTTPS enforcement, one-time tokens, and optional same-origin cookie login.
+Provides hardened REST endpoints for WordPress logins, user registration, and password resets with rate limiting, HTTPS enforcement, one-time tokens, and optional same-origin cookie login.
 
 == Description ==
 
-GN Password Login API exposes a JSON endpoint (`POST /wp-json/gn/v1/login`) that accepts a username or email address together with a password and optional `remember`, `mode`, and `redirect_to` fields. It is designed for JavaScript single-page apps, native mobile applications, and other cross-origin clients that need to authenticate against WordPress without showing the core login form.
+GN Password Login API exposes JSON endpoints (`/wp-json/gn/v1/*`) for logging in, registering, and initiating password resets. Login accepts a username or email address together with a password and optional `remember`, `mode`, and `redirect_to` fields, while registration validates new accounts and forgot-password leverages WordPress' built-in reset flow. It is designed for JavaScript single-page apps, native mobile applications, and other cross-origin clients that need to manage WordPress accounts without showing the core forms.
 
 Key features:
 
 * Requires HTTPS (unless explicitly allowed in development) and supports username or email based authentication.
-* Rate limits attempts to 5 per 15 minutes per IP and username and returns generic error messages to avoid user enumeration.
+* Rate limits login attempts to 5 per 15 minutes per IP and username and returns generic error messages to avoid user enumeration.
 * Default `token` mode returns a one-time token and login URL with a 60 second TTL; tokens are tied to the requesting IP and user agent and are consumed at `/wp-login.php?action=gn_token_login&token=...&u=...`.
 * Optional `cookie` mode sets the normal WordPress auth cookies immediately for same-origin usage.
+* Registration endpoint validates usernames, enforces unique emails, and requires passwords of at least eight characters.
+* Forgot-password endpoint triggers the standard WordPress reset email while keeping responses generic when the account is unknown.
 * Settings page at **Settings ▸ GN Login API** lets administrators whitelist a single external origin for CORS while keeping same-origin access functional.
 
 == Installation ==
@@ -43,7 +45,15 @@ Send a POST request with `mode` omitted or set to `token`. On success you will r
 
 Only when using the `cookie` mode from the same origin as the WordPress site. Cross-origin clients should use the token flow to avoid CORS credential issues.
 
+= How do registration and password reset work? =
+
+Send a POST request to `/wp-json/gn/v1/register` with `username`, `email`, and `password` (plus optional profile fields) to create a new account. To start a reset email, POST `/wp-json/gn/v1/forgot-password` with the user's username or email; the response message is intentionally generic to prevent account enumeration.
+
 == Changelog ==
+
+= 1.1.0 =
+* Added REST endpoints for user registration and initiating password resets.
+* Documented new flows and strengthened password requirements for new accounts.
 
 = 1.0.2 =
 * Version bump for maintenance release.
@@ -52,6 +62,9 @@ Only when using the `cookie` mode from the same origin as the WordPress site. Cr
 * Initial public release of the hardened password login REST API.
 
 == Upgrade Notice ==
+
+= 1.1.0 =
+Adds registration and password reset endpoints for complete account management from external clients.
 
 = 1.0.2 =
 Version bump for maintenance release.


### PR DESCRIPTION
## Summary
- add `POST /wp-json/gn/v1/register` with validation for new accounts and `POST /wp-json/gn/v1/forgot-password` to initiate resets without user enumeration
- document the new endpoints, security considerations, and version bump in both readmes

## Testing
- php -l gn-password-login-api.php

------
https://chatgpt.com/codex/tasks/task_e_68dbe9dec0848327b172bbf20210b781