### PR TITLE
Add REST endpoint for authenticated password changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ GN Password Login API is a WordPress plugin that exposes hardened REST endpoints
 - **Account registration endpoint:** `POST /wp-json/gn/v1/register` creates a new user with validated username, email, and password (optional profile fields supported).
 - **Password reset initiation:** `POST /wp-json/gn/v1/forgot-password` triggers the core WordPress reset email without revealing whether the account exists.
 - **Direct password reset:** `POST /wp-json/gn/v1/reset-password` lets you confirm the user through a custom verification code and immediately update the password without sending the default email.
+- **Authenticated password change:** `POST /wp-json/gn/v1/change-password` lets logged-in users rotate their password after confirming the current one.
 - **HTTPS enforcement:** rejects requests made over insecure HTTP (unless `ALLOW_DEV_HTTP` is enabled for local development).
 - **Rate limiting:** caps login attempts to 5 per 15-minute window per IP address and username.
 - **Flexible identifiers:** allows users to authenticate using either their username or email address.
@@ -140,6 +141,32 @@ Successful response:
 ```
 
 If you prefer your own verification logic, hook into the `gn_password_api_validate_reset_verification` filter. Return `true` to allow the reset, `false` to reject it, or a `WP_Error` for a custom error response.
+
+### Password change (authenticated users)
+
+```http
+POST /wp-json/gn/v1/change-password HTTP/1.1
+Host: example.com
+Content-Type: application/json
+Cookie: wordpress_logged_in=...
+
+{
+  "current_password": "existing password",
+  "new_password": "a new, stronger password",
+  "confirm_password": "a new, stronger password"
+}
+```
+
+Successful response:
+
+```json
+{
+  "success": true,
+  "message": "Password updated successfully."
+}
+```
+
+The endpoint requires the caller to already be authenticated (via cookies or another REST auth method), enforces the same minimum length as registration, re-validates the current password, and refreshes the session after the password change.
 
 ## Configuration
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: rest api, login, authentication, mobile, spa
 Requires at least: 5.8
 Tested up to: 6.4
 Requires PHP: 7.4
-Stable tag: 1.2.0
+Stable tag: 1.3.0
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,7 @@ Key features:
 * Registration endpoint validates usernames, enforces unique emails, and requires passwords of at least eight characters.
 * Forgot-password endpoint triggers the standard WordPress reset email while keeping responses generic when the account is unknown.
 * Direct reset endpoint lets you verify users through a custom code and update their password immediately without sending the default email.
+* Authenticated change-password endpoint lets logged-in users rotate their password after confirming the current one.
 * Settings page at **Settings ▸ GN Login API** lets administrators whitelist a single external origin for CORS while keeping same-origin access functional.
 
 == Installation ==
@@ -54,6 +55,10 @@ If you need to avoid the default email entirely, issue a one-time code with `GN_
 
 == Changelog ==
 
+= 1.3.0 =
+* Added an authenticated REST endpoint for users to change their own password after confirming the current credential.
+* Automatically refreshes the session after a successful password change and documents the new flow.
+
 = 1.2.0 =
 * Added a REST endpoint for direct password resets with custom verification.
 * Introduced helper method for issuing verification codes and documented the new flow.
@@ -69,6 +74,9 @@ If you need to avoid the default email entirely, issue a one-time code with `GN_
 * Initial public release of the hardened password login REST API.
 
 == Upgrade Notice ==
+
+= 1.3.0 =
+Adds an authenticated change-password endpoint and refreshes the session after a successful update.
 
 = 1.2.0 =
 Adds a direct password reset endpoint and helper for issuing custom verification codes.


### PR DESCRIPTION
## Summary
- add a /gn/v1/change-password REST route that lets logged-in users rotate their own passwords over HTTPS
- validate the current password, enforce strength, refresh the session, and fire a new action hook after updates
- bump the plugin to version 1.3.0 and document the endpoint in README files

## Testing
- php -l gn-password-login-api.php

------
https://chatgpt.com/codex/tasks/task_e_68dc02bfcc388327bc5ef9615c41262b