### PR TITLE
Extend token login TTL to one year

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ GN Password Login API is a WordPress plugin that exposes hardened REST endpoints
 - **Rate limiting:** caps login attempts to 5 per 15-minute window per IP address and username.
 - **Flexible identifiers:** allows users to authenticate using either their username or email address.
 - **Two response modes:**
-  - `mode: token` (default) returns a one-time login URL and token with a 60-second TTL for secure cross-origin hand-offs.
+  - `mode: token` (default) returns a one-time login URL and token with a one-year TTL for secure cross-origin hand-offs.
   - `mode: cookie` sets the WordPress auth cookies immediately for same-origin browser use.
 - **Single-use token consumption:** `/wp-login.php?action=gn_token_login&token=...&u=...` consumes the token, verifies IP/UA, and redirects to a safe internal URL.
 - **CORS control:** settings page under **Settings ▸ GN Login API** lets administrators whitelist a single external origin; same-origin requests work out-of-the-box.
@@ -42,7 +42,7 @@ Successful token-mode response:
   "success": true,
   "mode": "token",
   "token": "550e8400-e29b-41d4-a716-446655440000",
-  "token_expires_in": 60,
+  "token_expires_in": 31536000,
   "token_login_url": "https://example.com/wp-login.php?action=gn_token_login&token=...",
   "user": {
     "id": 123,
@@ -180,7 +180,7 @@ The endpoint requires the caller to already be authenticated (via cookies or ano
 - Registration validates usernames, enforces unique emails, and requires passwords of at least eight characters.
 - Password reset responses remain generic when the account is unknown to avoid user enumeration.
 - The plugin intentionally returns a generic error message for failed logins to avoid user enumeration.
-- One-time tokens expire after 60 seconds and are restricted to the requesting IP/UA pair for additional safety.
+- One-time tokens expire after one year and are restricted to the requesting IP/UA pair for additional safety.
 - Redirect targets are sanitized to prevent external redirects.
 
 ## Development

--- a/gn-password-login-api.php
+++ b/gn-password-login-api.php
@@ -16,7 +16,7 @@ class GN_Password_Login_API {
         const OPTION_KEY     = 'gn_login_api_settings';
         const ATTEMPT_LIMIT  = 5;      // attempts per window
         const WINDOW_SECONDS = 15 * 60; // 15 minutes
-        const TOKEN_TTL      = 60;     // 60 seconds (one-time login token)
+        const TOKEN_TTL      = YEAR_IN_SECONDS; // 1 year (one-time login token)
         const ALLOW_DEV_HTTP = false;  // set true only on local dev
         const PASSWORD_MIN_LENGTH = 8;
         const RESET_CODE_META_KEY = '_gn_password_api_reset_code';

--- a/readme.txt
+++ b/readme.txt
@@ -19,7 +19,7 @@ Key features:
 
 * Requires HTTPS (unless explicitly allowed in development) and supports username or email based authentication.
 * Rate limits login attempts to 5 per 15 minutes per IP and username and returns generic error messages to avoid user enumeration.
-* Default `token` mode returns a one-time token and login URL with a 60 second TTL; tokens are tied to the requesting IP and user agent and are consumed at `/wp-login.php?action=gn_token_login&token=...&u=...`.
+* Default `token` mode returns a one-time token and login URL with a one year TTL; tokens are tied to the requesting IP and user agent and are consumed at `/wp-login.php?action=gn_token_login&token=...&u=...`.
 * Optional `cookie` mode sets the normal WordPress auth cookies immediately for same-origin usage.
 * Registration endpoint validates usernames, enforces unique emails, and requires passwords of at least eight characters.
 * Forgot-password endpoint triggers the standard WordPress reset email while keeping responses generic when the account is unknown.
@@ -41,7 +41,7 @@ No. The endpoint enforces HTTPS and returns an error when accessed insecurely un
 
 = How do I use the token login flow? =
 
-Send a POST request with `mode` omitted or set to `token`. On success you will receive `token_login_url`; opening that URL in a browser within 60 seconds will set the auth cookies (respecting the `remember` flag) and redirect to the sanitized `redirect_to` value.
+Send a POST request with `mode` omitted or set to `token`. On success you will receive `token_login_url`; opening that URL in a browser within one year will set the auth cookies (respecting the `remember` flag) and redirect to the sanitized `redirect_to` value.
 
 = Can I set cookies directly from another domain? =
 


### PR DESCRIPTION
## Summary
- extend the one-time login token TTL to one year to support long-lived sessions
- refresh README documentation to reflect the new expiry window

## Testing
- php -l gn-password-login-api.php

------
https://chatgpt.com/codex/tasks/task_e_68dd0eddd818832793885dc04c5fad3c