### PR TITLE
Bump plugin version to 1.3.1

### DIFF
--- a/gn-password-login-api.php
+++ b/gn-password-login-api.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Password Login API
  * Description: Secure REST login via username/email + password with rate limiting, HTTPS checks, and one-time token login URL for cross-origin/mobile apps.
- * Version: 1.3.0
+ * Version: 1.3.1
  * Author: George Nicolaou
  * License: GPL-2.0+
  */

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: rest api, login, authentication, mobile, spa
 Requires at least: 5.8
 Tested up to: 6.4
 Requires PHP: 7.4
-Stable tag: 1.3.0
+Stable tag: 1.3.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -55,6 +55,9 @@ If you need to avoid the default email entirely, issue a one-time code with `GN_
 
 == Changelog ==
 
+= 1.3.1 =
+* Version bump for maintenance release.
+
 = 1.3.0 =
 * Added an authenticated REST endpoint for users to change their own password after confirming the current credential.
 * Automatically refreshes the session after a successful password change and documents the new flow.
@@ -74,6 +77,9 @@ If you need to avoid the default email entirely, issue a one-time code with `GN_
 * Initial public release of the hardened password login REST API.
 
 == Upgrade Notice ==
+
+= 1.3.1 =
+Maintenance release.
 
 = 1.3.0 =
 Adds an authenticated change-password endpoint and refreshes the session after a successful update.


### PR DESCRIPTION
## Summary
- bump the plugin header version to 1.3.1
- update the readme stable tag, changelog, and upgrade notice for the 1.3.1 maintenance release

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd11faecf4832793125ecefb7d91fd