### PR TITLE
Bump plugin version to 1.3.3

### DIFF
--- a/gn-password-login-api.php
+++ b/gn-password-login-api.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GN Password Login API
  * Description: Secure REST login via username/email + password with rate limiting, HTTPS checks, and one-time token login URL for cross-origin/mobile apps.
- * Version: 1.3.2
+ * Version: 1.3.3
  * Author: George Nicolaou
  * License: GPL-2.0+
  */

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: rest api, login, authentication, mobile, spa
 Requires at least: 5.8
 Tested up to: 6.4
 Requires PHP: 7.4
-Stable tag: 1.3.2
+Stable tag: 1.3.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -61,6 +61,9 @@ If you need to avoid the default email entirely, issue a one-time code with `GN_
 
 == Changelog ==
 
+= 1.3.3 =
+* Version bump for maintenance release.
+
 = 1.3.2 =
 * Allow token login URLs to work across differing IPs/user agents by default while providing filters to opt in to strict locking.
 * Add a final validation filter that can veto token logins before cookies are issued.
@@ -88,6 +91,9 @@ If you need to avoid the default email entirely, issue a one-time code with `GN_
 * Initial public release of the hardened password login REST API.
 
 == Upgrade Notice ==
+
+= 1.3.3 =
+Maintenance release.
 
 = 1.3.2 =
 Improves compatibility of token login URLs across browsers/devices and introduces new filters for optional strict locking.


### PR DESCRIPTION
## Summary
- bump the plugin header to version 1.3.3
- update the readme stable tag, changelog, and upgrade notice for the 1.3.3 maintenance release

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd526d02b0832787ff1d3201b9adbd